### PR TITLE
Support .NET Standard 1.0

### DIFF
--- a/CG.Pluralization/CG.Pluralization.csproj
+++ b/CG.Pluralization/CG.Pluralization.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
     <DocumentationFile></DocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>

--- a/CG.Pluralization/PolyfillUtilities.cs
+++ b/CG.Pluralization/PolyfillUtilities.cs
@@ -1,0 +1,45 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="PolyfillUtilities.cs" company="Andrew Arnott">
+//      Copyright (c) Andrew Arnott.  All rights reserved.
+// </copyright>
+//
+// @owner       Andrew Arnott
+//---------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+
+namespace CG.Pluralization
+{
+    internal static class PolyfillUtilities
+    {
+#if !NETSTANDARD2_0
+        internal static string ToLower(this string value, CultureInfo cultureInfo)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (cultureInfo == null)
+            {
+                throw new ArgumentNullException(nameof(cultureInfo));
+            }
+
+            return cultureInfo.TextInfo.ToLower(value);
+        }
+
+        internal static bool EndsWith(this string value, string suffix, bool ignoreCase, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            culture = culture ?? CultureInfo.CurrentCulture;
+
+            return culture.CompareInfo.IsSuffix(value, suffix, ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None);
+        }
+#endif
+    }
+}

--- a/CG.Pluralization/Properties/Resources.Designer.cs
+++ b/CG.Pluralization/Properties/Resources.Designer.cs
@@ -10,6 +10,7 @@
 
 namespace CG.Pluralization.Properties {
     using System;
+    using System.Reflection;
     
     
     /// <summary>
@@ -39,7 +40,7 @@ namespace CG.Pluralization.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CG.Pluralization.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CG.Pluralization.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;


### PR DESCRIPTION
This was fairly trivial -- only two methods were missing which were easily implemented as extension methods in order to not touch the original code at all.

I also removed the explicit netcoreapp2.0 targeted build since nothing was added to it over the netstandard2.0 version.

Please do not *squash* this PR, since I am building on this commit in my fork and squashing will erase the commit ID and result in merge conflicts down the road (at least for me).