### PR TITLE
Version with Nerdbank.GitVersioning

### DIFF
--- a/CG.Pluralization/CG.Pluralization.csproj
+++ b/CG.Pluralization/CG.Pluralization.csproj
@@ -9,7 +9,6 @@
     <IncludeSource>true</IncludeSource>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>0.2018.1</Version>
     <Description>This package contains a portable version of the .NET pluralization service from the System.Data.Entity.Design namespace, that works with .NET 4.61 or above, .NET Core 2.x, or .NET Standard 2.x.
 
 </Description>
@@ -20,7 +19,6 @@
     <Authors>Martin Cook</Authors>
     <Company>CodeGator</Company>
     <PackageIconUrl>http://www.codegator.com/packageDefaultIcon-50x50.png</PackageIconUrl>
-    <FileVersion>0.2018.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,6 +34,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" />
   </ItemGroup>
 
 </Project>

--- a/CG.Pluralization/CG.Pluralization.csproj
+++ b/CG.Pluralization/CG.Pluralization.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,8 @@
-version: 0.2018.4.{build}
+version: '{build}'
 image: Visual Studio 2017
-assembly_info:
-  patch: true
-  file: '**\AssemblyInfo.*'
-  assembly_version: '{version}'
-  assembly_file_version: '{version}'
-  assembly_informational_version: '{version}'
-dotnet_csproj:
-  patch: true
-  file: '**\*.csproj'
-  version: '{version}'
-  package_version: '{version}'
-  assembly_version: '{version}'
-  file_version: '{version}'
-  informational_version: '{version}'
 branches:
     only:
-      - master  
+      - master
 environment:
   COVERALLS_REPO_TOKEN:
     secure: cbqlOmIX0yBIg1IsaBazw4VMFM8zL9Yaee77k2XsdsSN3cEXLkOHJ4knRlLxtzBE

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositorypath" value="packages" />
+  </config>
+  <packageSources>
+    <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.3000",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
This allows for:
 * Unique versions in forks with no source changes
 * No magic on appveyor -- it all works exactly the same as local builds

Please do not *squash* this PR, since I am building on this commit in my fork and squashing will erase the commit ID and result in merge conflicts down the road (at least for me).