### PR TITLE
Stop generating binding redirects in library

### DIFF
--- a/CG.Pluralization/CG.Pluralization.csproj
+++ b/CG.Pluralization/CG.Pluralization.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <DocumentationFile></DocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Only tests and applications need binding redirects. It's meaningless for a library to have them.

Please do not *squash* this PR, since I am building on this commit in my fork and squashing will erase the commit ID and result in merge conflicts down the road (at least for me).